### PR TITLE
feat: update GetBreRoofType to allow users with pitched roofs who don…

### DIFF
--- a/SeaPublicWebsite/Services/RecommendationService.cs
+++ b/SeaPublicWebsite/Services/RecommendationService.cs
@@ -204,7 +204,7 @@ namespace SeaPublicWebsite.Services
             BreWallType breWallType = GetBreWallType(userData.WallConstruction.Value, userData.SolidWallsInsulated,
                 userData.CavityWallsInsulated);
 
-            BreRoofType breRoofType = GetBreRoofType(userData.RoofConstruction.Value, userData.RoofInsulated);
+            BreRoofType breRoofType = GetBreRoofType(userData.RoofConstruction.Value, userData.AccessibleLoftSpace, userData.RoofInsulated);
 
             BreGlazingType breGlazingType = GetBreGlazingType(userData.GlazingType.Value);
 
@@ -379,20 +379,26 @@ namespace SeaPublicWebsite.Services
             };
         }
 
-        private static BreRoofType GetBreRoofType(RoofConstruction roofConstruction, RoofInsulated? roofInsulated)
+        private static BreRoofType GetBreRoofType(RoofConstruction roofConstruction,
+            AccessibleLoftSpace? accessibleLoftSpace, RoofInsulated? roofInsulated)
         {
             return roofConstruction switch
             {
                 RoofConstruction.Flat =>
                     //assumption:
                     BreRoofType.FlatRoofWithInsulation,
-                RoofConstruction.Pitched or RoofConstruction.Mixed => roofInsulated switch
+                RoofConstruction.Pitched or RoofConstruction.Mixed => accessibleLoftSpace switch
                 {
-                    RoofInsulated.DoNotKnow => BreRoofType.DontKnow,
-                    //assumption in case RoofConstruction.Mixed:
-                    RoofInsulated.Yes => BreRoofType.PitchedRoofWithInsulation,
-                    //assumption in case RoofConstruction.Mixed:
-                    RoofInsulated.No => BreRoofType.PitchedRoofWithoutInsulation,
+                    AccessibleLoftSpace.No or AccessibleLoftSpace.DoNotKnow => BreRoofType.DontKnow,
+                    AccessibleLoftSpace.Yes => roofInsulated switch
+                    {
+                        RoofInsulated.DoNotKnow => BreRoofType.DontKnow,
+                        //assumption in case RoofConstruction.Mixed:
+                        RoofInsulated.Yes => BreRoofType.PitchedRoofWithInsulation,
+                        //assumption in case RoofConstruction.Mixed:
+                        RoofInsulated.No => BreRoofType.PitchedRoofWithoutInsulation,
+                        _ => throw new ArgumentOutOfRangeException()
+                    },
                     _ => throw new ArgumentOutOfRangeException()
                 },
                 _ => throw new ArgumentOutOfRangeException()


### PR DESCRIPTION
…'t know about (or have no) accessible loft space

This fix alters the GetBreRoofType function to avoid error in case user has pitched roof but no accessible space to check insulation (or doesn’t know if they do)