### PR TITLE
Seabeta 274 reset contradictory fields

### DIFF
--- a/SeaPublicWebsite.UnitTests/ResetUnusedFieldsTests.cs
+++ b/SeaPublicWebsite.UnitTests/ResetUnusedFieldsTests.cs
@@ -1,0 +1,241 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using SeaPublicWebsite.DataModels;
+using SeaPublicWebsite.Helpers;
+using SeaPublicWebsite.Models.EnergyEfficiency.QuestionOptions;
+
+namespace Tests;
+
+public class ResetUnusedFieldsTests
+{
+    
+    [TestCaseSource(nameof(TestCases))]
+    public void RunResetUnusedFieldTestCases(ResetUnusedFieldsTestCase testCase)
+    {
+        // Arrange
+        var userData = testCase.Input;
+        
+        // Act
+        UserDataHelper.ResetUnusedFields(userData);
+
+        // Assert
+        userData.Should().BeEquivalentTo(testCase.ExpectedOutput);
+    }
+
+    private static ResetUnusedFieldsTestCase[] TestCases =
+    {
+        new(
+            "Setting property type to house resets bungalow type and flat type",
+            new()
+            {
+                PropertyType = PropertyType.House,
+                HouseType = HouseType.Detached,
+                BungalowType = BungalowType.Terraced,
+                FlatType = FlatType.MiddleFloor
+            },
+            new()
+            {
+                PropertyType = PropertyType.House,
+                HouseType = HouseType.Detached
+            }
+        ),
+        new(
+            "Setting property type to bungalow resets house type and flat type",
+            new()
+            {
+                PropertyType = PropertyType.Bungalow,
+                HouseType = HouseType.Detached,
+                BungalowType = BungalowType.Terraced,
+                FlatType = FlatType.MiddleFloor
+            },
+            new()
+            {
+                PropertyType = PropertyType.Bungalow,
+                BungalowType = BungalowType.Terraced
+            }
+        ),
+        new(
+            "Setting property type to flat resets house type and bungalow type",
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                HouseType = HouseType.Detached,
+                BungalowType = BungalowType.Terraced,
+                FlatType = FlatType.MiddleFloor
+            },
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.MiddleFloor
+            }
+        ),
+        new(
+            "Setting wall construction to solid resets cavity insulation",
+            new()
+            {
+                WallConstruction = WallConstruction.Solid,
+                SolidWallsInsulated = SolidWallsInsulated.Some,
+                CavityWallsInsulated = CavityWallsInsulated.Some
+            },
+            new()
+            {
+                WallConstruction = WallConstruction.Solid,
+                SolidWallsInsulated = SolidWallsInsulated.Some,
+            }
+        ),
+        new(
+            "Setting wall construction to cavity resets solid insulation",
+            new()
+            {
+                WallConstruction = WallConstruction.Cavity,
+                SolidWallsInsulated = SolidWallsInsulated.Some,
+                CavityWallsInsulated = CavityWallsInsulated.Some
+            },
+            new()
+            {
+                WallConstruction = WallConstruction.Cavity,
+                CavityWallsInsulated = CavityWallsInsulated.Some
+            }
+        ),
+        new(
+            "Setting property to a non-ground apartment resets floor fields",
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.TopFloor,
+                FloorConstruction = FloorConstruction.Mix,
+                FloorInsulated = FloorInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.TopFloor,
+            }
+        ),
+        new(
+            "Setting property to a non-roof apartment resets roof fields",
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.GroundFloor,
+                RoofConstruction = RoofConstruction.Mixed,
+                AccessibleLoftSpace = AccessibleLoftSpace.Yes,
+                RoofInsulated = RoofInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.GroundFloor,
+            }
+        ),
+        new(
+            "Setting property to a middle apartment resets floor and roof fields",
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.MiddleFloor,
+                FloorConstruction = FloorConstruction.Mix,
+                FloorInsulated = FloorInsulated.Yes,
+                RoofConstruction = RoofConstruction.Mixed,
+                AccessibleLoftSpace = AccessibleLoftSpace.Yes,
+                RoofInsulated = RoofInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.ApartmentFlatOrMaisonette,
+                FlatType = FlatType.MiddleFloor,
+            }
+        ),
+        new(
+            "Setting floor construction to an unknown type resets floor insulation",
+            new()
+            {
+                PropertyType = PropertyType.House,
+                FloorConstruction = FloorConstruction.Other,
+                FloorInsulated = FloorInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.House,
+                FloorConstruction = FloorConstruction.Other,
+            }
+        ),
+        new(
+            "Setting roof construction to flat type resets accessible loft space and roof insulation",
+            new()
+            {
+                PropertyType = PropertyType.House,
+                RoofConstruction = RoofConstruction.Flat,
+                AccessibleLoftSpace = AccessibleLoftSpace.Yes,
+                RoofInsulated = RoofInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.House,
+                RoofConstruction = RoofConstruction.Flat,
+            }
+        ),
+        new(
+            "Setting accessible loft space to not be 'Yes' resets roof insulation",
+            new()
+            {
+                PropertyType = PropertyType.House,
+                RoofConstruction = RoofConstruction.Mixed,
+                AccessibleLoftSpace = AccessibleLoftSpace.DoNotKnow,
+                RoofInsulated = RoofInsulated.Yes
+            },
+            new()
+            {
+                PropertyType = PropertyType.House,
+                RoofConstruction = RoofConstruction.Mixed,
+                AccessibleLoftSpace = AccessibleLoftSpace.DoNotKnow,
+            }
+        ),
+        new(
+            "Setting heating type not to 'Other' resets other heating type",
+            new()
+            {
+                HeatingType = HeatingType.GasBoiler,
+                OtherHeatingType = OtherHeatingType.Biomass,
+                HasHotWaterCylinder = HasHotWaterCylinder.Yes
+            },
+            new()
+            {
+                HeatingType = HeatingType.GasBoiler,
+                HasHotWaterCylinder = HasHotWaterCylinder.Yes
+            }
+        ),
+        new(
+            "Setting heating type not to Gas boiler, Oil boiler or Lpg boiler resets has hot water cylinder",
+            new()
+            {
+                HeatingType = HeatingType.Storage,
+                OtherHeatingType = OtherHeatingType.Biomass,
+                HasHotWaterCylinder = HasHotWaterCylinder.Yes
+            },
+            new()
+            {
+                HeatingType = HeatingType.Storage,
+            }
+        ),
+    };
+    
+    public class ResetUnusedFieldsTestCase
+    {
+        public readonly string Description;
+        public readonly UserDataModel Input;
+        public readonly UserDataModel ExpectedOutput;
+
+        public ResetUnusedFieldsTestCase(string description, UserDataModel input, UserDataModel expectedOutput)
+        {
+            Description = description;
+            Input = input;
+            ExpectedOutput = expectedOutput;
+        }
+
+        public override string ToString()
+        {
+            return Description;
+        }
+    }
+}

--- a/SeaPublicWebsite/Controllers/EnergyEfficiencyController.cs
+++ b/SeaPublicWebsite/Controllers/EnergyEfficiencyController.cs
@@ -26,7 +26,12 @@ namespace SeaPublicWebsite.Controllers
         private readonly IEmailSender emailApi;
         private readonly RecommendationService recommendationService;
 
-        public EnergyEfficiencyController(UserDataStore userDataStore, IQuestionFlowService questionFlowService, IEpcApi epcApi, IEmailSender emailApi, RecommendationService recommendationService)
+        public EnergyEfficiencyController(
+            UserDataStore userDataStore, 
+            IQuestionFlowService questionFlowService, 
+            IEpcApi epcApi, 
+            IEmailSender emailApi, 
+            RecommendationService recommendationService)
         {
             this.userDataStore = userDataStore;
             this.questionFlowService = questionFlowService;
@@ -200,6 +205,7 @@ namespace SeaPublicWebsite.Controllers
 
             userDataModel.Postcode = viewModel.Postcode;
             userDataModel.HouseNameOrNumber = viewModel.HouseNameOrNumber;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.AskForPostcode, userDataModel);
@@ -246,6 +252,7 @@ namespace SeaPublicWebsite.Controllers
             var epc = (await epcApi.GetEpcsForPostcode(userDataModel.Postcode)).FirstOrDefault(e => e.EpcId == viewModel.SelectedEpcId);
             userDataModel.Epc = epc;
 
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.ConfirmAddress, userDataModel);
@@ -281,6 +288,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.PropertyType = viewModel.PropertyType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.PropertyType, userDataModel, viewModel.EntryPoint);
@@ -315,6 +323,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.HouseType = viewModel.HouseType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.HouseType, userDataModel, viewModel.EntryPoint);
@@ -350,6 +359,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
             
             userDataModel.BungalowType = viewModel.BungalowType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.BungalowType, userDataModel, viewModel.EntryPoint);
@@ -385,6 +395,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.FlatType = viewModel.FlatType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.FlatType, userDataModel, viewModel.EntryPoint);
@@ -423,6 +434,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
             
             userDataModel.YearBuilt = viewModel.YearBuilt;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.HomeAge, userDataModel, viewModel.EntryPoint);
@@ -460,6 +472,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.WallConstruction = viewModel.WallConstruction;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.WallConstruction, userDataModel, viewModel.EntryPoint);
@@ -498,6 +511,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.CavityWallsInsulated = viewModel.CavityWallsInsulated;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.CavityWallsInsulated, userDataModel, viewModel.EntryPoint);
@@ -536,6 +550,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
             
             userDataModel.SolidWallsInsulated = viewModel.SolidWallsInsulated;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.SolidWallsInsulated, userDataModel, viewModel.EntryPoint);
@@ -574,6 +589,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.FloorConstruction = viewModel.FloorConstruction;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.FloorConstruction, userDataModel, viewModel.EntryPoint);
@@ -611,6 +627,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.FloorInsulated = viewModel.FloorInsulated;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs =
@@ -648,6 +665,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.RoofConstruction = viewModel.RoofConstruction;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.RoofConstruction, userDataModel, viewModel.EntryPoint);
@@ -682,6 +700,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.AccessibleLoftSpace = viewModel.AccessibleLoftSpace;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.AccessibleLoftSpace, userDataModel, viewModel.EntryPoint);
@@ -717,6 +736,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.RoofInsulated = viewModel.RoofInsulated;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.RoofInsulated, userDataModel, viewModel.EntryPoint);
@@ -752,6 +772,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.GlazingType = viewModel.GlazingType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.GlazingType, userDataModel, viewModel.EntryPoint);
@@ -786,6 +807,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.HasOutdoorSpace = viewModel.HasOutdoorSpace;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.OutdoorSpace, userDataModel, viewModel.EntryPoint);
@@ -822,6 +844,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.HeatingType = viewModel.HeatingType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.HeatingType, userDataModel, viewModel.EntryPoint);
@@ -857,6 +880,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.OtherHeatingType = viewModel.OtherHeatingType;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.OtherHeatingType, userDataModel, viewModel.EntryPoint);
@@ -892,6 +916,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.HasHotWaterCylinder = viewModel.HasHotWaterCylinder;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.HotWaterCylinder, userDataModel, viewModel.EntryPoint);
@@ -929,6 +954,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.NumberOfOccupants = viewModel.NumberOfOccupants;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.NumberOfOccupants, userDataModel, viewModel.EntryPoint);
@@ -967,6 +993,7 @@ namespace SeaPublicWebsite.Controllers
             userDataModel.HeatingPattern = viewModel.HeatingPattern;
             userDataModel.HoursOfHeating = viewModel.HeatingPattern == HeatingPattern.Other ? viewModel.HoursOfHeating : null;
 
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.HeatingPattern, userDataModel, viewModel.EntryPoint);
@@ -1004,6 +1031,7 @@ namespace SeaPublicWebsite.Controllers
             var userDataModel = userDataStore.LoadUserData(viewModel.Reference);
 
             userDataModel.Temperature = viewModel.Temperature;
+            UserDataHelper.ResetUnusedFields(userDataModel);
             userDataStore.SaveUserData(userDataModel);
 
             var forwardArgs = questionFlowService.ForwardLinkArguments(QuestionFlowPage.Temperature, userDataModel, viewModel.EntryPoint);

--- a/SeaPublicWebsite/Helpers/UserDataHelper.cs
+++ b/SeaPublicWebsite/Helpers/UserDataHelper.cs
@@ -113,5 +113,88 @@ namespace SeaPublicWebsite.Helpers
                        && (!userData.YearBuilt.HasValue && userData.Epc?.ConstructionAgeBand > HomeAge.From1996To2002 ||
                            userData.YearBuilt > 2002));
         }
+
+        public static bool HasAnsweredFloorQuestions(UserDataModel userData)
+        {
+            return (userData.PropertyType, userData.FlatType) switch
+            {
+                (PropertyType.House, _) or (PropertyType.Bungalow, _) or (PropertyType.ApartmentFlatOrMaisonette, FlatType.GroundFloor) => true,
+                _ => false
+            };
+        }
+        
+        public static bool HasAnsweredRoofQuestions(UserDataModel userData)
+        {
+            return (userData.PropertyType, userData.FlatType) switch
+            {
+                (PropertyType.House, _) or (PropertyType.Bungalow, _) or (PropertyType.ApartmentFlatOrMaisonette, FlatType.TopFloor) => true,
+                _ => false
+            };
+        }
+        
+        public static void ResetUnusedFields(UserDataModel userData)
+        {
+            if (userData.PropertyType is not PropertyType.House)
+            {
+                userData.HouseType = null;
+            }
+            
+            if (userData.PropertyType is not PropertyType.Bungalow)
+            {
+                userData.BungalowType = null;
+            }
+            
+            if (userData.PropertyType is not PropertyType.ApartmentFlatOrMaisonette)
+            {
+                userData.FlatType = null;
+            }
+            
+            if (userData.WallConstruction is not WallConstruction.Cavity and not WallConstruction.Mixed)
+            {
+                userData.CavityWallsInsulated = null;
+            }
+            
+            if (userData.WallConstruction is not WallConstruction.Solid and not WallConstruction.Mixed)
+            {
+                userData.SolidWallsInsulated = null;
+            }
+            
+            if (!HasAnsweredFloorQuestions(userData))
+            {
+                userData.FloorConstruction = null;
+            }
+
+            if (userData.FloorConstruction is not FloorConstruction.SolidConcrete
+                and not FloorConstruction.SuspendedTimber and not FloorConstruction.Mix)
+            {
+                userData.FloorInsulated = null;
+            }
+
+            if (!HasAnsweredRoofQuestions(userData))
+            {
+                userData.RoofConstruction = null;
+            }
+
+            if (userData.RoofConstruction is not RoofConstruction.Mixed and not RoofConstruction.Pitched)
+            {
+                userData.AccessibleLoftSpace = null;
+            }
+
+            if (userData.AccessibleLoftSpace is not AccessibleLoftSpace.Yes)
+            {
+                userData.RoofInsulated = null;
+            }
+
+            if (userData.HeatingType is not HeatingType.Other)
+            {
+                userData.OtherHeatingType = null;
+            }
+
+            if (userData.HeatingType is not HeatingType.GasBoiler and not HeatingType.OilBoiler
+                and not HeatingType.LpgBoiler)
+            {
+                userData.HasHotWaterCylinder = null;
+            }
+        }
     }
 }

--- a/SeaPublicWebsite/Helpers/UserDataHelper.cs
+++ b/SeaPublicWebsite/Helpers/UserDataHelper.cs
@@ -114,7 +114,7 @@ namespace SeaPublicWebsite.Helpers
                            userData.YearBuilt > 2002));
         }
 
-        public static bool HasAnsweredFloorQuestions(UserDataModel userData)
+        public static bool HasFloor(UserDataModel userData)
         {
             return (userData.PropertyType, userData.FlatType) switch
             {
@@ -123,7 +123,7 @@ namespace SeaPublicWebsite.Helpers
             };
         }
         
-        public static bool HasAnsweredRoofQuestions(UserDataModel userData)
+        public static bool HasRoof(UserDataModel userData)
         {
             return (userData.PropertyType, userData.FlatType) switch
             {
@@ -159,7 +159,7 @@ namespace SeaPublicWebsite.Helpers
                 userData.SolidWallsInsulated = null;
             }
             
-            if (!HasAnsweredFloorQuestions(userData))
+            if (!HasFloor(userData))
             {
                 userData.FloorConstruction = null;
             }
@@ -170,7 +170,7 @@ namespace SeaPublicWebsite.Helpers
                 userData.FloorInsulated = null;
             }
 
-            if (!HasAnsweredRoofQuestions(userData))
+            if (!HasRoof(userData))
             {
                 userData.RoofConstruction = null;
             }

--- a/SeaPublicWebsite/Services/QuestionFlowService.cs
+++ b/SeaPublicWebsite/Services/QuestionFlowService.cs
@@ -257,7 +257,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
+            if (UserDataHelper.HasFloor(userData))
             {
                 return userData.FloorConstruction switch
                 {
@@ -301,7 +301,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return userData switch
                 {
@@ -313,7 +313,7 @@ namespace SeaPublicWebsite.Services
                 };
             }
 
-            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
+            if (UserDataHelper.HasFloor(userData))
             {
                 return userData.FloorConstruction switch
                 {
@@ -530,12 +530,12 @@ namespace SeaPublicWebsite.Services
             }
 
             // These options below are for people who have chosen "Don't know" to "What type of walls do you have?"
-            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
+            if (UserDataHelper.HasFloor(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency", new { reference });
             }
@@ -563,12 +563,12 @@ namespace SeaPublicWebsite.Services
             }
 
             // These options below are for people who have finished the "wall insulation" questions (e.g. who only have cavity walls)
-            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
+            if (UserDataHelper.HasFloor(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency",new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -584,12 +584,12 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
+            if (UserDataHelper.HasFloor(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency",new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -611,7 +611,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -627,7 +627,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
+            if (UserDataHelper.HasRoof(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }

--- a/SeaPublicWebsite/Services/QuestionFlowService.cs
+++ b/SeaPublicWebsite/Services/QuestionFlowService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SeaPublicWebsite.Controllers;
 using SeaPublicWebsite.DataModels;
+using SeaPublicWebsite.Helpers;
 using SeaPublicWebsite.Models.EnergyEfficiency.QuestionOptions;
 
 namespace SeaPublicWebsite.Services
@@ -256,7 +257,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (HasFloor(userData))
+            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
             {
                 return userData.FloorConstruction switch
                 {
@@ -300,7 +301,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return userData switch
                 {
@@ -312,7 +313,7 @@ namespace SeaPublicWebsite.Services
                 };
             }
 
-            if (HasFloor(userData))
+            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
             {
                 return userData.FloorConstruction switch
                 {
@@ -529,12 +530,12 @@ namespace SeaPublicWebsite.Services
             }
 
             // These options below are for people who have chosen "Don't know" to "What type of walls do you have?"
-            if (HasFloor(userData))
+            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency", new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency", new { reference });
             }
@@ -562,12 +563,12 @@ namespace SeaPublicWebsite.Services
             }
 
             // These options below are for people who have finished the "wall insulation" questions (e.g. who only have cavity walls)
-            if (HasFloor(userData))
+            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency",new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -583,12 +584,12 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (HasFloor(userData))
+            if (UserDataHelper.HasAnsweredFloorQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.FloorConstruction_Get), "EnergyEfficiency",new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -610,7 +611,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -626,7 +627,7 @@ namespace SeaPublicWebsite.Services
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference });
             }
 
-            if (HasRoof(userData))
+            if (UserDataHelper.HasAnsweredRoofQuestions(userData))
             {
                 return new PathByActionArguments(nameof(EnergyEfficiencyController.RoofConstruction_Get), "EnergyEfficiency",new { reference });
             }
@@ -787,24 +788,6 @@ namespace SeaPublicWebsite.Services
         {
             var reference = userData.Reference;
             return new PathByActionArguments(nameof(EnergyEfficiencyController.AnswerSummary), "EnergyEfficiency", new { reference  });
-        }
-
-        private bool HasFloor(UserDataModel userData)
-        {
-            return (userData.PropertyType, userData.FlatType) switch
-            {
-                (PropertyType.House, _) or (PropertyType.Bungalow, _) or (PropertyType.ApartmentFlatOrMaisonette, FlatType.GroundFloor) => true,
-                _ => false
-            };
-        }
-
-        private bool HasRoof(UserDataModel userData)
-        {
-            return (userData.PropertyType, userData.FlatType) switch
-            {
-                (PropertyType.House, _) or (PropertyType.Bungalow, _) or (PropertyType.ApartmentFlatOrMaisonette, FlatType.TopFloor) => true,
-                _ => false
-            };
         }
     }
 


### PR DESCRIPTION
From a design perspective, whenever an UserDataModel field is updated I call the ResetUnusedFields method to set to 'null' fields that became unreachable.