### PR TITLE
fix: Use GovUk data binders where appropriate

### DIFF
--- a/SeaPublicWebsite/Models/EnergyEfficiency/HeatingPatternViewModel.cs
+++ b/SeaPublicWebsite/Models/EnergyEfficiency/HeatingPatternViewModel.cs
@@ -1,4 +1,7 @@
-﻿using GovUkDesignSystem.Attributes.ValidationAttributes;
+﻿using GovUkDesignSystem.Attributes.DataBinding;
+using GovUkDesignSystem.Attributes.ValidationAttributes;
+using GovUkDesignSystem.ModelBinders;
+using Microsoft.AspNetCore.Mvc;
 using SeaPublicWebsite.Models.EnergyEfficiency.QuestionOptions;
 
 namespace SeaPublicWebsite.Models.EnergyEfficiency
@@ -8,11 +11,15 @@ namespace SeaPublicWebsite.Models.EnergyEfficiency
         [GovUkValidateRequired(ErrorMessageIfMissing = "Select heating pattern")]
         public HeatingPattern? HeatingPattern { get; set; }
         
-        [GovUkValidateRequiredIf(ErrorMessageIfMissing = "Enter number of hours", IsRequiredPropertyName = nameof(IsRequiredHoursOfHeating))]
+        [ModelBinder(typeof(GovUkOptionalIntBinder))]
+        [GovUkDataBindingOptionalIntErrorText("Number of hours in the morning")]
+        [GovUkValidateRequiredIf(ErrorMessageIfMissing = "Enter number of hours in the morning", IsRequiredPropertyName = nameof(IsRequiredHoursOfHeating))]
         [GovUkValidateIntRange("Number of hours", 0, 12)]
         public int? HoursOfHeatingMorning { get; set; }
         
-        [GovUkValidateRequiredIf(ErrorMessageIfMissing = "Enter number of hours", IsRequiredPropertyName = nameof(IsRequiredHoursOfHeating))]
+        [ModelBinder(typeof(GovUkOptionalIntBinder))]
+        [GovUkDataBindingOptionalIntErrorText("Number of hours in the afternoon and evening")]
+        [GovUkValidateRequiredIf(ErrorMessageIfMissing = "Enter number of hours in the afternoon and evening", IsRequiredPropertyName = nameof(IsRequiredHoursOfHeating))]
         [GovUkValidateIntRange("Number of hours", 0, 12)]
         public int? HoursOfHeatingEvening { get; set; }
 

--- a/SeaPublicWebsite/Models/EnergyEfficiency/HomeAgeViewModel.cs
+++ b/SeaPublicWebsite/Models/EnergyEfficiency/HomeAgeViewModel.cs
@@ -1,12 +1,16 @@
-﻿using GovUkDesignSystem.Attributes.ValidationAttributes;
+﻿using GovUkDesignSystem.Attributes.DataBinding;
+using GovUkDesignSystem.Attributes.ValidationAttributes;
+using GovUkDesignSystem.ModelBinders;
+using Microsoft.AspNetCore.Mvc;
 using SeaPublicWebsite.Models.EnergyEfficiency.QuestionOptions;
 
 namespace SeaPublicWebsite.Models.EnergyEfficiency
 {
     public class HomeAgeViewModel : QuestionFlowViewModel
     {
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the approximate year that your property was built")]
-        [GovUkValidateIntRange("The year your property was build", 1000, 2022)]
+        [ModelBinder(typeof(GovUkMandatoryIntBinder))]
+        [GovUkDataBindingMandatoryIntErrorText("Enter the approximate year that your property was built", "The year your property was built")]
+        [GovUkValidateIntRange("The year your property was built", 1000, 2022)]
         public int? YearBuilt { get; set; }
 
         public string Reference { get; set; }

--- a/SeaPublicWebsite/Models/EnergyEfficiency/NumberOfOccupantsViewModel.cs
+++ b/SeaPublicWebsite/Models/EnergyEfficiency/NumberOfOccupantsViewModel.cs
@@ -1,11 +1,15 @@
-﻿using GovUkDesignSystem.Attributes.ValidationAttributes;
+﻿using GovUkDesignSystem.Attributes.DataBinding;
+using GovUkDesignSystem.Attributes.ValidationAttributes;
+using GovUkDesignSystem.ModelBinders;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SeaPublicWebsite.Models.EnergyEfficiency
 {
     public class NumberOfOccupantsViewModel : QuestionFlowViewModel
     {
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the number of people who live in the property")]
-        [GovUkValidateIntRange("Number of occupants", 1, 9)]
+        [ModelBinder(typeof(GovUkMandatoryIntBinder))]
+        [GovUkDataBindingMandatoryIntErrorText("Enter the number of people who live in the property", "The number of people who live in the property")]
+        [GovUkValidateIntRange("The number of people who live in the property", 1, 9)]
         public int? NumberOfOccupants { get; set; }
 
         public string Reference { get; set; }

--- a/SeaPublicWebsite/Models/EnergyEfficiency/TemperatureViewModel.cs
+++ b/SeaPublicWebsite/Models/EnergyEfficiency/TemperatureViewModel.cs
@@ -1,10 +1,14 @@
-﻿using GovUkDesignSystem.Attributes.ValidationAttributes;
+﻿using GovUkDesignSystem.Attributes.DataBinding;
+using GovUkDesignSystem.Attributes.ValidationAttributes;
+using GovUkDesignSystem.ModelBinders;
+using Microsoft.AspNetCore.Mvc;
 
 namespace SeaPublicWebsite.Models.EnergyEfficiency
 {
     public class TemperatureViewModel : QuestionFlowViewModel
     {
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter a number between 5 and 35, or skip this question")]
+        [ModelBinder(typeof(GovUkMandatoryDecimalBinder))]
+        [GovUkDataBindingMandatoryDecimalErrorText("Enter a number between 5 and 35, or skip this question", "The temperature")]
         [GovUkValidateDecimalRange("The temperature", 5, 35)]
         public decimal? Temperature { get; set; }
         public string Reference { get; set; }

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using GovUkDesignSystem.ModelBinders;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -56,6 +57,7 @@ namespace SeaPublicWebsite
             {
                 options.Filters.Add<ErrorHandlingFilter>();
                 options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+                options.ModelMetadataDetailsProviders.Add(new GovUkDataBindingErrorTextProvider());
             });
 
             services.AddScoped<RecommendationService>();


### PR DESCRIPTION
Whenever we are asking a user for numeric or date inputs we should use the GovUK databinding attributes to make sure that the generated error messages fit the GovUk guidelines.