### PR TITLE
seabeta-283 Running migrations on GOV.PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Migrations will be run automatically on deployment. If a migration needs to be r
 2. Generate and run a rollback script
    1. Check out the same commit locally
    2. [Install EF Core CLI tools](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) if you haven't already
-   3. Generate a rollback script using `dotnet ef migrations script 2022010112345678_BadMigration 2022010112345678_LastGoodMigration` from the `SeaPublicWebsite` directory
+   3. Generate a rollback script using `dotnet ef migrations script 2022010112345678_BadMigration 2022010112345678_LastGoodMigration -o revert.sql` from the `SeaPublicWebsite` directory
    4. Review the script 
    5. Connect to the database using cf conduit
        1. If you haven't used conduit before: `cf install-plugin conduit`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Fill in the opened `secrets.json` file with:
 
 ### Creating/updating the local database
 
-- In the terminal (from the solution directory) run `dotnet ef database update --project .\SeaPublicWebsite`
+- You can just run the website project and it will create and update the database on startup
+- If you want to manually update the database (e.g. to test a new migration) in the terminal (from the solution directory) run `dotnet ef database update --project .\SeaPublicWebsite`
 
 ### Adding Migrations
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Improve Your Property's Energy Efficiency BETA
 
+## Deployment
+
+The site is deployed using github actions.
+
+### Database Migrations
+
+Migrations will be run automatically on deployment. If a migration needs to be rolled back for any reason there are two options:
+1. Create an new inverse migration and deploy that
+2. Generate and run a rollback script
+   1. Check out the same commit locally
+   2. [Install EF Core CLI tools](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) if you haven't already
+   3. Generate a rollback script using `dotnet ef migrations script 2022010112345678_BadMigration 2022010112345678_LastGoodMigration` from the `SeaPublicWebsite` directory
+   4. Review the script 
+   5. Connect to the database using cf conduit
+       1. If you haven't used conduit before: `cf install-plugin conduit`
+       2. `cf conduit sea-beta-<Environment>-db`
+   6. Use pgAdmin or similar with the credentials from cf conduit to run the rollback script
+
 ## Development
 
 ### Pre-requisites

--- a/SeaPublicWebsite/Program.cs
+++ b/SeaPublicWebsite/Program.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using SeaPublicWebsite.Data;
 using Serilog;
 using Serilog.Events;
-using Serilog.Sinks.Network;
 
 namespace SeaPublicWebsite
 {
@@ -11,6 +13,7 @@ namespace SeaPublicWebsite
     {
         public static void Main(string[] args)
         {
+            // Create a Serilog bootstrap logger
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                 .Enrich.FromLogContext()
@@ -22,6 +25,7 @@ namespace SeaPublicWebsite
             var startup = new Startup(builder.Configuration, builder.Environment);
             startup.ConfigureServices(builder.Services);
 
+            // Switch to the full Serilog logger
             builder.Host.UseSerilog((context, services, configuration) => configuration
                 .ReadFrom.Configuration(context.Configuration)
                 .ReadFrom.Services(services)
@@ -31,6 +35,16 @@ namespace SeaPublicWebsite
             var app = builder.Build();
 
             startup.Configure(app, app.Environment);
+            
+            // Migrate the database for local dev and for instance 0 on GOV.PaaS.
+            // As we use rolling deployments there shouldn't be any chance of multiple instances of this running at the
+            // same time anyway, but it's easy to check the instance index for extra safety.
+            if (app.Environment.IsDevelopment() || app.Configuration["CF_INSTANCE_INDEX"] == "0")
+            {
+                using var scope = app.Services.CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<SeaDbContext>();
+                dbContext.Database.Migrate();
+            }
 
             app.Run();
         }

--- a/SeaPublicWebsite/Program.cs
+++ b/SeaPublicWebsite/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -47,15 +46,6 @@ namespace SeaPublicWebsite
             }
 
             app.Run();
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args)
-        {
-            IHostBuilder webHostBuilder = Host.CreateDefaultBuilder(args);
-
-            webHostBuilder.ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
-            
-            return webHostBuilder;
         }
     }
 }


### PR DESCRIPTION
Running migrations on app start up is not normally considered best practice (Microsoft have some reasons here: https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#apply-migrations-at-runtime). However on GOV.PaaS I think that it's actually a reasonable way to do it compared to the alternatives.

Objections and counter arguments:
- If multiple instances of your application are running, both applications could attempt to apply the migration concurrently and fail (or worse, cause data corruption).
  - We ensure that only instance 0 runs the migrations
- Similarly, if an application is accessing the database while another application migrates it, this can cause severe issues.
  - We want to aim for 100% uptime so there will always be code accessing the DB during migrations. We need to write non-breaking migrations.
- The application must have elevated access to modify the database schema. It's generally good practice to limit the application's database permissions in production.
  - On GOV.PaaS we don't appear to have the ability to change our DB permissions anyway
- It's important to be able to roll back an applied migration in case of an issue. The other strategies provide this easily and out of the box.
  - This is not ideal, but I think we can live with it, we can roll back migrations from a dev machine using `cf conduit` to connect to the database. Or we can create an inverse migration and deploy that.
- The SQL commands are applied directly by the program, without giving the developer a chance to inspect or modify them. This can be dangerous in a production environment.
  - We'll be running the migrations in dev and probably a staging environment first anyway which should catch any problems likely to be caught by manual SQL review.

Alternatives:
- Run the migration directly from a github action
  - This would mean running `cf conduit` on github and then parsing the returned text to extract the DB details before using them to run the migration.
- Create CloudFoundry tasks to run the migrations (https://docs.cloudfoundry.org/devguide/using-tasks.html)
  - This is what I would look into if we had to move away from the solution in this PR
  - We would need to set up the tasks and ensure that we would be alerted to migration failure.
  - We would also need to re-jig the deployment process so that we could run the task on the new deployment code (so it has the migration) before actually deploying the new code.
  - In theory we could probably set up an action to revert the last migration