### PR TITLE
fix: Allow multiple property details to use the same EPC

### DIFF
--- a/SeaPublicWebsite.BusinessLogic/Models/Epc.cs
+++ b/SeaPublicWebsite.BusinessLogic/Models/Epc.cs
@@ -6,6 +6,8 @@ namespace SeaPublicWebsite.BusinessLogic.Models
 {
     public class Epc
     {
+        // PRIMARY KEY
+        public int Id { get; set; }
         public string Address1 { get; set; }
         public string Address2 { get; set; }
         public string Postcode { get; set; }

--- a/SeaPublicWebsite.Data/Migrations/20220614163252_AddDedicatedPrimaryKeyToEpcTable.Designer.cs
+++ b/SeaPublicWebsite.Data/Migrations/20220614163252_AddDedicatedPrimaryKeyToEpcTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SeaPublicWebsite.Data;
@@ -11,9 +12,10 @@ using SeaPublicWebsite.Data;
 namespace SeaPublicWebsite.Data.Migrations
 {
     [DbContext(typeof(SeaDbContext))]
-    partial class SeaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220614163252_AddDedicatedPrimaryKeyToEpcTable")]
+    partial class AddDedicatedPrimaryKeyToEpcTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SeaPublicWebsite.Data/Migrations/20220614163252_AddDedicatedPrimaryKeyToEpcTable.cs
+++ b/SeaPublicWebsite.Data/Migrations/20220614163252_AddDedicatedPrimaryKeyToEpcTable.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace SeaPublicWebsite.Data.Migrations
+{
+    public partial class AddDedicatedPrimaryKeyToEpcTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                    name: "Id",
+                    table: "Epc",
+                    type: "integer",
+                    nullable: false,
+                    defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+            
+            migrationBuilder.DropForeignKey(
+                name: "FK_PropertyData_Epc_EpcId",
+                table: "PropertyData");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Epc",
+                table: "Epc");
+            
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Epc",
+                table: "Epc",
+                column: "Id");
+
+            migrationBuilder.RenameColumn(
+                name: "EpcId",
+                table: "PropertyData",
+                newName: "EpcIdOld");
+
+            migrationBuilder.AddColumn<int>(
+                name: "EpcId",
+                table: "PropertyData",
+                type: "integer",
+                nullable: true
+            );
+            
+            migrationBuilder.Sql(@"
+                UPDATE public.""PropertyData""
+                SET ""EpcId"" = ""Epc"".""Id""
+                FROM public.""Epc""
+                WHERE ""Epc"".""EpcId"" = ""PropertyData"".""EpcIdOld""");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EpcId",
+                table: "Epc",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PropertyData_Epc_EpcId",
+                table: "PropertyData",
+                column: "EpcId",
+                principalTable: "Epc",
+                principalColumn: "Id");
+
+            migrationBuilder.DropColumn(
+                name: "EpcIdOld",
+                table: "PropertyData");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PropertyData_Epc_EpcId",
+                table: "PropertyData");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Epc",
+                table: "Epc");
+            
+            migrationBuilder.RenameColumn(
+                name: "EpcId",
+                table: "PropertyData",
+                newName: "EpcIdOld");
+
+            migrationBuilder.AddColumn<string>(
+                name: "EpcId",
+                table: "PropertyData",
+                type: "text",
+                nullable: true
+            );
+            
+            migrationBuilder.Sql(@"
+                UPDATE public.""PropertyData""
+                SET ""EpcId"" = ""Epc"".""EpcId""
+                FROM public.""Epc""
+                WHERE ""Epc"".""Id"" = ""PropertyData"".""EpcIdOld""");
+            
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "Epc");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EpcId",
+                table: "Epc",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Epc",
+                table: "Epc",
+                column: "EpcId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PropertyData_Epc_EpcId",
+                table: "PropertyData",
+                column: "EpcId",
+                principalTable: "Epc",
+                principalColumn: "EpcId");
+            
+            migrationBuilder.DropColumn(
+                name: "EpcIdOld",
+                table: "PropertyData");
+        }
+    }
+}


### PR DESCRIPTION
The issue was that EF Core had taken the `EpcId` column as the primary key and so disallowed multiple rows for the same EPC