### PR TITLE
fix: Stop getting loft insulation recommendation when there is no loft

### DIFF
--- a/SeaPublicWebsite/Services/RecommendationService.cs
+++ b/SeaPublicWebsite/Services/RecommendationService.cs
@@ -339,7 +339,8 @@ namespace SeaPublicWebsite.Services
                     BreRoofType.FlatRoofWithInsulation,
                 RoofConstruction.Pitched or RoofConstruction.Mixed => loftSpace switch
                 {
-                    LoftSpace.No => BreRoofType.DontKnow,
+                    //peer-reviewed assumption:
+                    LoftSpace.No => BreRoofType.PitchedRoofWithInsulation,
                     LoftSpace.Yes => loftAccess switch
                     {
                         LoftAccess.No => BreRoofType.DontKnow,


### PR DESCRIPTION
Checked this with Joanna as a sensible assumption. Also tested that it does indeed fix the issue