### PR TITLE
feat: Log postcode errors and allow user to continue

### DIFF
--- a/SeaPublicWebsite/Controllers/EnergyEfficiencyController.cs
+++ b/SeaPublicWebsite/Controllers/EnergyEfficiencyController.cs
@@ -30,6 +30,7 @@ namespace SeaPublicWebsite.Controllers
         private readonly RecommendationService recommendationService;
         private readonly CookieService cookieService;
         private readonly GoogleAnalyticsService googleAnalyticsService;
+        private readonly PostcodesIoApi postcodesIoApi;
 
         public EnergyEfficiencyController(
             PropertyDataStore propertyDataStore,
@@ -38,7 +39,8 @@ namespace SeaPublicWebsite.Controllers
             IEmailSender emailApi, 
             RecommendationService recommendationService,
             CookieService cookieService,
-            GoogleAnalyticsService googleAnalyticsService)
+            GoogleAnalyticsService googleAnalyticsService,
+            PostcodesIoApi postcodesIoApi)
         {
             this.propertyDataStore = propertyDataStore;
             this.propertyDataStore = propertyDataStore;
@@ -48,6 +50,7 @@ namespace SeaPublicWebsite.Controllers
             this.recommendationService = recommendationService;
             this.cookieService = cookieService;
             this.googleAnalyticsService = googleAnalyticsService;
+            this.postcodesIoApi = postcodesIoApi;
         }
         
         [HttpGet("")]
@@ -199,7 +202,7 @@ namespace SeaPublicWebsite.Controllers
         [HttpPost("postcode/{reference}")]
         public async Task<IActionResult> AskForPostcode_Post(AskForPostcodeViewModel viewModel)
         {
-            if (viewModel.Postcode is not null && !PostcodesIoApi.IsValidPostcode(viewModel.Postcode))
+            if (viewModel.Postcode is not null && !(await postcodesIoApi.IsValidPostcode(viewModel.Postcode)))
             {
                 ModelState.AddModelError(nameof(AskForPostcodeViewModel.Postcode), "Enter a valid UK post code");
             }

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -17,6 +17,7 @@ using SeaPublicWebsite.ExternalServices.Bre;
 using SeaPublicWebsite.ExternalServices.EmailSending;
 using SeaPublicWebsite.ExternalServices.EpbEpc;
 using SeaPublicWebsite.ExternalServices.GoogleAnalytics;
+using SeaPublicWebsite.ExternalServices.PostcodesIo;
 using SeaPublicWebsite.Middleware;
 using SeaPublicWebsite.Services;
 using SeaPublicWebsite.Services.Cookies;
@@ -40,6 +41,7 @@ namespace SeaPublicWebsite
         {
             services.AddScoped<PropertyDataStore, PropertyDataStore>();
             services.AddScoped<IQuestionFlowService, QuestionFlowService>();
+            services.AddScoped<PostcodesIoApi>();
             services.AddMemoryCache();
             services.AddSingleton<StaticAssetsVersioningService>();
             services.AddScoped<RecommendationService>();


### PR DESCRIPTION
In general we shouldn't stop user's entering their postcodes if postcodes.io falls over.
This is especially true for the load test