### PR TITLE
feat: name antiforgery token explicitly and hide kestrel header

### DIFF
--- a/SeaPublicWebsite/Program.cs
+++ b/SeaPublicWebsite/Program.cs
@@ -22,6 +22,7 @@ namespace SeaPublicWebsite
             
             var builder = WebApplication.CreateBuilder(args);
             
+            //Hide that we are using Kestrel for security reasons
             builder.WebHost.ConfigureKestrel(serverOptions => serverOptions.AddServerHeader = false);
             
             var startup = new Startup(builder.Configuration, builder.Environment);

--- a/SeaPublicWebsite/Program.cs
+++ b/SeaPublicWebsite/Program.cs
@@ -22,7 +22,7 @@ namespace SeaPublicWebsite
             
             var builder = WebApplication.CreateBuilder(args);
             
-            //Hide that we are using Kestrel for security reasons
+            // Hide that we are using Kestrel for security reasons
             builder.WebHost.ConfigureKestrel(serverOptions => serverOptions.AddServerHeader = false);
             
             var startup = new Startup(builder.Configuration, builder.Environment);

--- a/SeaPublicWebsite/Program.cs
+++ b/SeaPublicWebsite/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,6 +21,8 @@ namespace SeaPublicWebsite
                 .CreateBootstrapLogger();
             
             var builder = WebApplication.CreateBuilder(args);
+            
+            builder.WebHost.ConfigureKestrel(serverOptions => serverOptions.AddServerHeader = false);
             
             var startup = new Startup(builder.Configuration, builder.Environment);
             startup.ConfigureServices(builder.Services);

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -112,6 +112,7 @@ namespace SeaPublicWebsite
         {
             services.Configure<CookieServiceConfiguration>(
                 configuration.GetSection(CookieServiceConfiguration.ConfigSection));
+            services.AddAntiforgery(options => options.Cookie.Name = "Antiforgery");
             services.AddScoped<CookieService, CookieService>();
         }
 

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -112,6 +112,7 @@ namespace SeaPublicWebsite
         {
             services.Configure<CookieServiceConfiguration>(
                 configuration.GetSection(CookieServiceConfiguration.ConfigSection));
+            //Change the default antiforgery cookie name so it doesn't include Asp.Net for security reasons
             services.AddAntiforgery(options => options.Cookie.Name = "Antiforgery");
             services.AddScoped<CookieService, CookieService>();
         }

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -112,7 +112,7 @@ namespace SeaPublicWebsite
         {
             services.Configure<CookieServiceConfiguration>(
                 configuration.GetSection(CookieServiceConfiguration.ConfigSection));
-            //Change the default antiforgery cookie name so it doesn't include Asp.Net for security reasons
+            // Change the default antiforgery cookie name so it doesn't include Asp.Net for security reasons
             services.AddAntiforgery(options => options.Cookie.Name = "Antiforgery");
             services.AddScoped<CookieService, CookieService>();
         }


### PR DESCRIPTION
tested locally
minimal risk - this change is only cosmetic as far as I can see from the relevant docs
no documentation required