### PR TITLE
fet: add security headers

### DIFF
--- a/SeaPublicWebsite/Middleware/SecurityHeadersMiddleware.cs
+++ b/SeaPublicWebsite/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace SeaPublicWebsite.Middleware;
+
+public class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate next;
+    
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        this.next = next;
+    }
+
+    public Task Invoke(HttpContext context)
+    {
+        context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+        context.Response.Headers.Add("Content-Security-Policy", "default-src 'self");
+        context.Response.Headers.Add("Referrer-Policy", "no-referrer");
+
+        return next(context);
+    }
+}

--- a/SeaPublicWebsite/Startup.cs
+++ b/SeaPublicWebsite/Startup.cs
@@ -161,7 +161,9 @@ namespace SeaPublicWebsite
             app.UseAuthorization();
 
             ConfigureHttpBasicAuth(app);
-            
+
+            app.UseMiddleware<SecurityHeadersMiddleware>();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();


### PR DESCRIPTION
Tested locally
Risks: I've not yet had much time to read fully into the docs for these changes, would another pair of eyes looking through to make sure I'm using these correctly :) In general though no huge changes have been made, it's possible the content security policy header has disabled some external functionality I wasn't aware we were using.
No documentation required