### PR TITLE
BEISSEA-67 Use CloudFoundry's apt buildpack to install Chrome's dependencies when an instance starts

### DIFF
--- a/SeaPublicWebsite/apt.yml
+++ b/SeaPublicWebsite/apt.yml
@@ -1,0 +1,16 @@
+---
+packages:
+  - libnss3
+  - libnssutil3
+  - libsmime3
+  - libnspr4
+  - libatk-1.0
+  - libatk-bridge-2.0
+  - libcups
+  - libatspi
+  - libXcomposite
+  - libXdamage
+  - libXrandr
+  - libgbm
+  - libxkbcommon
+  - libasound

--- a/SeaPublicWebsite/manifest.yml
+++ b/SeaPublicWebsite/manifest.yml
@@ -1,6 +1,7 @@
 ﻿---
 applications:
  - buildpacks:
+     - https://github.com/cloudfoundry/apt-buildpack
      - dotnet_core_buildpack
    command: dotnet SeaPublicWebsite.dll
    health-check-http-endpoint: /health-check


### PR DESCRIPTION
This is, I think, the right way to do this. CloudFoundry's apt buildpack is apparently "experimental" but it's been around for 6 years and is still maintained. All it does is install the dependencies you list in `apt.yml`.