### PR TITLE
Fix Puppeteer on new platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ COPY . ./
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&\
 apt-get install -y nodejs
 
+# Install required packages for Puppeteer
+RUN apt-get install -y libcups2 libatspi2.0-0 libxcomposite1 libxdamage1  \
+    libxrandr2 libgbm1 libxkbcommon0 libasound2 libnspr4 libnss3 libatk1.0-0 libatk-bridge2.0-0
+
 # Build node assets
 WORKDIR /SeaPublicWebsite/SeaPublicWebsite
 RUN npm install


### PR DESCRIPTION
Copied the list of packages we needed to install on gov PaaS to the Dockerfile