### PR TITLE
BEISSEA-NONE Move Chrome installation to base image instead of build image

### DIFF
--- a/SeaPublicWebsite/SeaPublicWebsite.csproj
+++ b/SeaPublicWebsite/SeaPublicWebsite.csproj
@@ -20,7 +20,7 @@
       <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0-preview.3.23174.8" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
-      <PackageReference Include="PuppeteerSharp" Version="10.0.0" />
+      <PackageReference Include="PuppeteerSharp" Version="11.0.5" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />

--- a/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
+++ b/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Options;
 using PuppeteerSharp;
 using PuppeteerSharp.Media;
@@ -14,14 +10,10 @@ namespace SeaPublicWebsite.Services.EnergyEfficiency.PdfGeneration;
 public class PdfGenerationService
 {
     private readonly BasicAuthMiddlewareConfiguration basicAuthConfiguration;
-    private readonly IServer server;
 
-    public PdfGenerationService(
-        IOptions<BasicAuthMiddlewareConfiguration> basicAuthOptions,
-        IServer server)
+    public PdfGenerationService(IOptions<BasicAuthMiddlewareConfiguration> basicAuthOptions)
     {
         basicAuthConfiguration = basicAuthOptions.Value;
-        this.server = server;
     }
 
     // This function runs a headless chrome browser without a sandbox (--no-sandbox).
@@ -30,12 +22,9 @@ public class PdfGenerationService
     // https://softwiretech.atlassian.net/browse/BEISSEA-73
     public async Task<Stream> GeneratePdf(string path)
     {
-        await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
         var launchOptions = new LaunchOptions
         {
             Headless = true,
-            IgnoreDefaultArgs = true,
-            IgnoredDefaultArgs = new[] { "--disable-extensions" },
             Args = new [] { "--no-sandbox" }
         };
         
@@ -58,6 +47,6 @@ public class PdfGenerationService
 
     private string GetLocalAddress()
     {
-        return server.Features.Get<IServerAddressesFeature>().Addresses.First();
+        return "http://localhost:80";
     }
 }

--- a/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
+++ b/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
@@ -47,6 +47,7 @@ public class PdfGenerationService
 
     private string GetLocalAddress()
     {
+        // If the port the application runs on is ever changed this will need to be updated
         return "http://localhost:80";
     }
 }


### PR DESCRIPTION
Three key things here:
* We now install Chrome in Docker, not in .NET
* Chrome needs to be installed in the image we actually run .NET from, not the build image (this took me the longest to work out)
* Our old method for getting the local address started returning `http://[::]:80` which Chrome doesn't recognise as a valid address, so I've hardcoded it. I'm not very happy about doing that but since everything's in Docker the address should always be the same.