### PR TITLE
PC-572: Update home age options to match EPC bands

### DIFF
--- a/SeaPublicWebsite.BusinessLogic/ExternalServices/Bre/RecommendationService.cs
+++ b/SeaPublicWebsite.BusinessLogic/ExternalServices/Bre/RecommendationService.cs
@@ -244,11 +244,17 @@ namespace SeaPublicWebsite.BusinessLogic.ExternalServices.Bre
         {
             return yearBuilt switch
             {
-                YearBuilt.Pre1930 => "B",
-                YearBuilt.From1930To1966 => "D",
-                YearBuilt.From1967To1982 => "F",
-                YearBuilt.From1983To1995 => "H",
-                YearBuilt.From1996To2011 => "K",
+                YearBuilt.Pre1900 => "A",
+                YearBuilt.From1900To1929 or YearBuilt.Pre1930 => "B",
+                YearBuilt.From1930To1949 => "C",
+                YearBuilt.From1950To1966 or YearBuilt.From1930To1966=> "D",
+                YearBuilt.From1967To1975 => "E",
+                YearBuilt.From1976To1982 or YearBuilt.From1967To1982 => "F",
+                YearBuilt.From1983To1990 => "G",
+                YearBuilt.From1991To1995 or YearBuilt.From1983To1995 => "H",
+                YearBuilt.From1996To2002 => "I",
+                YearBuilt.From2003To2006 => "J",
+                YearBuilt.From2007To2011 or YearBuilt.From1996To2011 => "K",
                 YearBuilt.From2012ToPresent => "L",
                 //peer-reviewed assumptions:
                 _ => epcConstructionAgeBand switch

--- a/SeaPublicWebsite.BusinessLogic/Models/Enums/YearBuilt.cs
+++ b/SeaPublicWebsite.BusinessLogic/Models/Enums/YearBuilt.cs
@@ -4,18 +4,118 @@ namespace SeaPublicWebsite.BusinessLogic.Models.Enums;
 
 public enum YearBuilt
 {
+    // ⚠ IMPORTANT: Do not reorder this enum!
+    // Historic data is saved by enum value as an integer in the PropertyData table,
+    // so we must keep this order to maintain the correct mapping.
+
+    // The bands were redefined in PC-572: https://beisdigital.atlassian.net/browse/PC-572
+    // The deprecated bands from before this change are listed first, followed by the active bands.
+
+    // Deprecated age bands.
+
     [GovUkRadioCheckboxLabelText(Text = "Before 1930")]
+    [YearBuilt(MaxYear = 1929, Deprecated = true)]
     Pre1930,
+
     [GovUkRadioCheckboxLabelText(Text = "1930 to 1966")]
+    [YearBuilt(MaxYear = 1966, Deprecated = true)]
     From1930To1966,
+
     [GovUkRadioCheckboxLabelText(Text = "1967 to 1982")]
+    [YearBuilt(MaxYear = 1982, Deprecated = true)]
     From1967To1982,
+
     [GovUkRadioCheckboxLabelText(Text = "1983 to 1995")]
+    [YearBuilt(MaxYear = 1995, Deprecated = true)]
     From1983To1995,
+
     [GovUkRadioCheckboxLabelText(Text = "1996 to 2011")]
+    [YearBuilt(MaxYear = 2011, Deprecated = true)]
     From1996To2011,
+
+    // From2012ToPresent and DoNotKnow were introduced with the original (deprecated) age bands, but are still active.
+
     [GovUkRadioCheckboxLabelText(Text = "2012 or newer")]
+    [YearBuilt(MaxYear = int.MaxValue)]
     From2012ToPresent,
+
     [GovUkRadioCheckboxLabelText(Text = "I don't know")]
-    DoNotKnow
+    DoNotKnow,
+
+    // Active age bands.
+
+    [GovUkRadioCheckboxLabelText(Text = "Before 1900")]
+    [YearBuilt(MaxYear = 1899)]
+    Pre1900,
+
+    [GovUkRadioCheckboxLabelText(Text = "1900 to 1929")]
+    [YearBuilt(MaxYear = 1929)]
+    From1900To1929,
+
+    [GovUkRadioCheckboxLabelText(Text = "1930 to 1949")]
+    [YearBuilt(MaxYear = 1949)]
+    From1930To1949,
+
+    [GovUkRadioCheckboxLabelText(Text = "1950 to 1966")]
+    [YearBuilt(MaxYear = 1966)]
+    From1950To1966,
+
+    [GovUkRadioCheckboxLabelText(Text = "1967 to 1975")]
+    [YearBuilt(MaxYear = 1975)]
+    From1967To1975,
+
+    [GovUkRadioCheckboxLabelText(Text = "1976 to 1982")]
+    [YearBuilt(MaxYear = 1982)]
+    From1976To1982,
+
+    [GovUkRadioCheckboxLabelText(Text = "1983 to 1990")]
+    [YearBuilt(MaxYear = 1990)]
+    From1983To1990,
+
+    [GovUkRadioCheckboxLabelText(Text = "1991 to 1995")]
+    [YearBuilt(MaxYear = 1995)]
+    From1991To1995,
+
+    [GovUkRadioCheckboxLabelText(Text = "1996 to 2002")]
+    [YearBuilt(MaxYear = 2002)]
+    From1996To2002,
+
+    [GovUkRadioCheckboxLabelText(Text = "2003 to 2006")]
+    [YearBuilt(MaxYear = 2006)]
+    From2003To2006,
+
+    [GovUkRadioCheckboxLabelText(Text = "2007 to 2011")]
+    [YearBuilt(MaxYear = 2011)]
+    From2007To2011
+}
+
+[AttributeUsage(AttributeTargets.Field)]
+public class YearBuiltAttribute : Attribute
+{
+    public int MaxYear { get; set; }
+    public bool Deprecated { get; set; }
+}
+
+public static class YearBuiltExtensions
+{
+    public static bool? IsBefore(this YearBuilt yearBuilt, int year)
+    {
+        return yearBuilt == YearBuilt.DoNotKnow ? null : yearBuilt.MaxYear() < year;
+    }
+
+    public static int? MaxYear(this YearBuilt yearBuilt)
+    {
+        return yearBuilt.GetAttribute()?.MaxYear;
+    }
+
+    public static bool IsDeprecated(this YearBuilt yearBuilt)
+    {
+        return yearBuilt.GetAttribute()?.Deprecated ?? false;
+    }
+
+    private static YearBuiltAttribute GetAttribute(this YearBuilt yearBuilt)
+    {
+        var enumMember = typeof(YearBuilt).GetMember(yearBuilt.ToString()).SingleOrDefault();
+        return (YearBuiltAttribute)enumMember?.GetCustomAttributes(typeof(YearBuiltAttribute), false).SingleOrDefault();
+    }
 }

--- a/SeaPublicWebsite.BusinessLogic/Models/PropertyData.cs
+++ b/SeaPublicWebsite.BusinessLogic/Models/PropertyData.cs
@@ -48,13 +48,13 @@ public class PropertyData
 
     public List<PropertyRecommendation> PropertyRecommendations { get; set; } = new();
 
-    public bool? HintSolidWalls => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt <= Enums.YearBuilt.Pre1930;
-    public bool? HintUninsulatedCavityWalls => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt < Enums.YearBuilt.From1996To2011;
-    public bool? HintSuspendedTimber => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt < Enums.YearBuilt.From1967To1982;
-    public bool? HintUninsulatedFloor => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt < Enums.YearBuilt.From1996To2011;
+    public bool? HintSolidWalls => YearBuilt?.IsBefore(1930);
+    public bool? HintUninsulatedCavityWalls => YearBuilt?.IsBefore(1996);
+    public bool? HintSuspendedTimber => YearBuilt?.IsBefore(1967);
+    public bool? HintUninsulatedFloor => YearBuilt?.IsBefore(1996);
     public bool HintHaveLoftAndAccess => PropertyType is Enums.PropertyType.House or Enums.PropertyType.Bungalow;
-    public bool? HintUninsulatedRoof => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt < Enums.YearBuilt.From2012ToPresent;
-    public bool? HintSingleGlazing => YearBuilt is null or Enums.YearBuilt.DoNotKnow ? null : YearBuilt < Enums.YearBuilt.From1983To1995;
+    public bool? HintUninsulatedRoof => YearBuilt?.IsBefore(2012);
+    public bool? HintSingleGlazing => YearBuilt?.IsBefore(1983);
     public bool HintHasOutdoorSpace => PropertyType is Enums.PropertyType.House or Enums.PropertyType.Bungalow;
 
     public bool ShowAltRadiatorPanels => PropertyRecommendations.Exists(r =>

--- a/SeaPublicWebsite.BusinessLogic/PropertyDataUpdater.cs
+++ b/SeaPublicWebsite.BusinessLogic/PropertyDataUpdater.cs
@@ -74,17 +74,17 @@ public class PropertyDataUpdater
                     p.FlatType = epc.FlatType;
                     p.YearBuilt = epc.ConstructionAgeBand switch
                     {
-                        HomeAge.Pre1900 => YearBuilt.Pre1930,
-                        HomeAge.From1900To1929 => YearBuilt.Pre1930,
-                        HomeAge.From1930To1949 => YearBuilt.From1930To1966,
-                        HomeAge.From1950To1966 => YearBuilt.From1930To1966,
-                        HomeAge.From1967To1975 => YearBuilt.From1967To1982,
-                        HomeAge.From1976To1982 => YearBuilt.From1967To1982,
-                        HomeAge.From1983To1990 => YearBuilt.From1983To1995,
-                        HomeAge.From1991To1995 => YearBuilt.From1983To1995,
-                        HomeAge.From1996To2002 => YearBuilt.From1996To2011,
-                        HomeAge.From2003To2006 => YearBuilt.From1996To2011,
-                        HomeAge.From2007To2011 => YearBuilt.From1996To2011,
+                        HomeAge.Pre1900 => YearBuilt.Pre1900,
+                        HomeAge.From1900To1929 => YearBuilt.From1900To1929,
+                        HomeAge.From1930To1949 => YearBuilt.From1930To1949,
+                        HomeAge.From1950To1966 => YearBuilt.From1950To1966,
+                        HomeAge.From1967To1975 => YearBuilt.From1967To1975,
+                        HomeAge.From1976To1982 => YearBuilt.From1976To1982,
+                        HomeAge.From1983To1990 => YearBuilt.From1983To1990,
+                        HomeAge.From1991To1995 => YearBuilt.From1991To1995,
+                        HomeAge.From1996To2002 => YearBuilt.From1996To2002,
+                        HomeAge.From2003To2006 => YearBuilt.From2003To2006,
+                        HomeAge.From2007To2011 => YearBuilt.From2007To2011,
                         HomeAge.From2012ToPresent => YearBuilt.From2012ToPresent,
                         _ => throw new ArgumentOutOfRangeException()
                     };

--- a/SeaPublicWebsite.UnitTests/BusinessLogic/Models/PropertyDataTests.cs
+++ b/SeaPublicWebsite.UnitTests/BusinessLogic/Models/PropertyDataTests.cs
@@ -22,7 +22,7 @@ public class PropertyDataTests
             HouseType = HouseType.Detached,
             BungalowType = BungalowType.Detached,
             FlatType = FlatType.GroundFloor,
-            YearBuilt = YearBuilt.Pre1930,
+            YearBuilt = YearBuilt.Pre1900,
             WallConstruction = WallConstruction.Cavity,
             CavityWallsInsulated = CavityWallsInsulated.All,
             SolidWallsInsulated = SolidWallsInsulated.All,
@@ -146,7 +146,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.Pre1930
+            YearBuilt = YearBuilt.From1900To1929
         };
         
         // Assert
@@ -159,7 +159,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1930To1966
+            YearBuilt = YearBuilt.From1930To1949
         };
         
         // Assert
@@ -185,7 +185,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1983To1995
+            YearBuilt = YearBuilt.From1991To1995
         };
         
         // Assert
@@ -198,7 +198,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1996To2011
+            YearBuilt = YearBuilt.From1996To2002
         };
         
         // Assert
@@ -224,7 +224,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1930To1966
+            YearBuilt = YearBuilt.From1950To1966
         };
         
         // Assert
@@ -237,7 +237,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1967To1982
+            YearBuilt = YearBuilt.From1967To1975
         };
         
         // Assert
@@ -263,7 +263,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1983To1995
+            YearBuilt = YearBuilt.From1991To1995
         };
         
         // Assert
@@ -276,7 +276,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1996To2011
+            YearBuilt = YearBuilt.From1996To2002
         };
         
         // Assert
@@ -333,7 +333,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1996To2011
+            YearBuilt = YearBuilt.From2007To2011
         };
         
         // Assert
@@ -372,7 +372,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1967To1982
+            YearBuilt = YearBuilt.From1976To1982
         };
         
         // Assert
@@ -385,7 +385,7 @@ public class PropertyDataTests
         // Arrange
         var propertyData = new PropertyData
         {
-            YearBuilt = YearBuilt.From1983To1995
+            YearBuilt = YearBuilt.From1983To1990
         };
         
         // Assert

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithDiscardedRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithDiscardedRecommendations.cshtml
@@ -46,7 +46,7 @@
             {
                 <li>Install a heat pump - <a class="govuk-link" target="_blank" href="https://www.heat-pump-check.service.gov.uk/">Check if your home may be suitable</a></li>
             }
-            @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1930)
+            @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1900)
             {
                 <li>Visit the <a class="govuk-link" target="_blank" href="https://historicengland.org.uk/advice/your-home/energy-efficiency/">Historic England</a> site for information specific to historic buildings.</li>
             }

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithMaybeRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithMaybeRecommendations.cshtml
@@ -46,7 +46,7 @@
             {
                 <li>Install a heat pump - <a class="govuk-link" target="_blank" href="https://www.heat-pump-check.service.gov.uk/">Check if your home may be suitable</a></li>
             }
-            @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1930)
+            @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1900)
             {
                 <li>Visit the <a class="govuk-link" target="_blank" href="https://historicengland.org.uk/advice/your-home/energy-efficiency/">Historic England</a> site for information specific to historic buildings.</li>
             }

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithSavedRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithSavedRecommendations.cshtml
@@ -205,7 +205,7 @@
     {
         <li>Install a heat pump - <a class="govuk-link" target="_blank" href="https://www.heat-pump-check.service.gov.uk/">Check if your home may be suitable</a></li>
     }
-    @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1930)
+    @if (Model.PropertyData?.YearBuilt == YearBuilt.Pre1900)
     {
         <li>Visit the <a class="govuk-link" target="_blank" href="https://historicengland.org.uk/advice/your-home/energy-efficiency/">Historic England</a> site for information specific to historic buildings.</li>
     }

--- a/SeaPublicWebsite/Views/EnergyEfficiency/CavityWallsInsulated.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/CavityWallsInsulated.cshtml
@@ -27,7 +27,7 @@
             @{
                 Func<object, object> details = 
                     @<text>
-                        @if (Model.YearBuilt is >= YearBuilt.From1996To2011)
+                        @if (Model.YearBuilt == YearBuilt.DoNotKnow || Model.YearBuilt?.MaxYear() > 1991)
                         {
                             <p class="govuk-body">
                                 Homes built after 1991 were typically built with insulating material between the outer and inner walls. 

--- a/SeaPublicWebsite/Views/EnergyEfficiency/HomeAge.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/HomeAge.cshtml
@@ -48,11 +48,17 @@
                             Your @Model.Epc.LodgementYear Energy Performance Certificate suggests your property was built
                             <strong>
                                 @(Model.Epc?.ConstructionAgeBand switch {
-                                    HomeAge.Pre1900 or HomeAge.From1900To1929 => "before 1930.",
-                                    HomeAge.From1930To1949 or HomeAge.From1950To1966 => "between 1930 and 1966.",
-                                    HomeAge.From1967To1975 or HomeAge.From1976To1982 => "between 1967 and 1982.",
-                                    HomeAge.From1983To1990 or HomeAge.From1991To1995 => "between 1983 and 1995.",
-                                    HomeAge.From1996To2002 or HomeAge.From2003To2006 or HomeAge.From2007To2011 => "between 1996 and 2011.",
+                                    HomeAge.Pre1900 => "before 1900.",
+                                    HomeAge.From1900To1929 => "between 1900 and 1929.",
+                                    HomeAge.From1930To1949 => "between 1930 and 1949.",
+                                    HomeAge.From1950To1966 => "between 1950 and 1966.",
+                                    HomeAge.From1967To1975 => "between 1967 and 1975.",
+                                    HomeAge.From1976To1982 => "between 1976 and 1982.",
+                                    HomeAge.From1983To1990 => "between 1983 and 1990.",
+                                    HomeAge.From1991To1995 => "between 1991 and 1995.",
+                                    HomeAge.From1996To2002 => "between 1996 and 2002.",
+                                    HomeAge.From2003To2006 => "between 2003 and 2006.",
+                                    HomeAge.From2007To2011 => "between 2007 and 2011.",
                                     HomeAge.From2012ToPresent => "on or after 2012.",
                                     _ => throw new ArgumentOutOfRangeException()})
                             </strong>
@@ -93,7 +99,13 @@
                                }
                                
                             </text>
-                }))
+                },
+                overrideRadioValues: Enum.GetValues<YearBuilt>()
+                    .Except(new[] { YearBuilt.DoNotKnow })
+                    .Where(value => !value.IsDeprecated())
+                    .OrderBy(value => value.MaxYear())
+                    .Append(YearBuilt.DoNotKnow)
+                ))
             @(await Html.GovUkButton(new ButtonViewModel
             {
                 Text = "Continue",


### PR DESCRIPTION
This is a reworking of https://github.com/UKGovernmentBEIS/beis-simple-energy-advice-beta/pull/259.

The main difference is that we preserve the deprecated home age bands to support historic data.