### PR TITLE
PC-1122: Investigation into updating C# & .NET versions

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout code onto job runner
         uses: actions/checkout@v2
 
-      - name: Install .Net (6.0)
+      - name: Install .Net (8.0)
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+         dotnet-version: 8.0.x
 
       - name: Restore .Net dependencies
         run: dotnet restore --configfile Nuget.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 as base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 as base
 # Install Chrome
 RUN apt-get update && apt-get -f install && apt-get -y install wget gnupg2 apt-utils
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y google-chrome-stable --no-install-recommends --allow-downgrades fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
 ENV PUPPETEER_EXECUTABLE_PATH "/usr/bin/google-chrome-stable"
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /SeaPublicWebsite
 
 # Copy everything
@@ -36,5 +36,5 @@ RUN dotnet publish -c Release -o out
 FROM base
 WORKDIR /SeaPublicWebsite
 COPY --from=build-env /SeaPublicWebsite/out .
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["dotnet", "SeaPublicWebsite.dll"]

--- a/SeaPublicWebsite.BusinessLogic/SeaPublicWebsite.BusinessLogic.csproj
+++ b/SeaPublicWebsite.BusinessLogic/SeaPublicWebsite.BusinessLogic.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite.BusinessLogic/SeaPublicWebsite.BusinessLogic.csproj
+++ b/SeaPublicWebsite.BusinessLogic/SeaPublicWebsite.BusinessLogic.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite.Data/SeaPublicWebsite.Data.csproj
+++ b/SeaPublicWebsite.Data/SeaPublicWebsite.Data.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite.Data/SeaPublicWebsite.Data.csproj
+++ b/SeaPublicWebsite.Data/SeaPublicWebsite.Data.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite.UnitTests/SeaPublicWebsite.UnitTests.csproj
+++ b/SeaPublicWebsite.UnitTests/SeaPublicWebsite.UnitTests.csproj
@@ -5,7 +5,7 @@
         <IsPackable>false</IsPackable>
         <RootNamespace>Tests</RootNamespace>
         <IsPublishable>false</IsPublishable> 
-        <LangVersion>11</LangVersion> 
+        <LangVersion>12</LangVersion> 
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite.UnitTests/SeaPublicWebsite.UnitTests.csproj
+++ b/SeaPublicWebsite.UnitTests/SeaPublicWebsite.UnitTests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>Tests</RootNamespace>
         <IsPublishable>false</IsPublishable> 
+        <LangVersion>11</LangVersion> 
     </PropertyGroup>
 
     <ItemGroup>

--- a/SeaPublicWebsite/SeaPublicWebsite.csproj
+++ b/SeaPublicWebsite/SeaPublicWebsite.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>11</LangVersion>
         <UserSecretsId>b88a2d94-9041-47c6-ab29-ff57149dd347</UserSecretsId>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/SeaPublicWebsite/SeaPublicWebsite.csproj
+++ b/SeaPublicWebsite/SeaPublicWebsite.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
         <UserSecretsId>b88a2d94-9041-47c6-ab29-ff57149dd347</UserSecretsId>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
+++ b/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
@@ -55,6 +55,6 @@ public class PdfGenerationService
     private string GetLocalAddress()
     {
         // If the port the application runs on is ever changed this will need to be updated
-        return "http://localhost:80";
+        return "http://localhost:8080";
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   sea:
     build: .
     ports:
-      - "5001:80"
+      - "5001:8080"
     environment:
       ASPNETCORE_ENVIRONMENT: "Development"
     volumes:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0",
+    "version": "8.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0",
+    "version": "5.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION

[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1122)

# Description

- Updating C# from 10 to 11
- Updating .Net from 6 to 8
- Changing all references from old versions to new versions
- Breaking change in .Net 8 requires references to port 80 to become port 8080.
- Updated SDK version in global.json from 5.0 -> 8.0
- Some additional warnings in editor (115 warnings to 150)

# Checklist (Investigation results, not full PR)

- [ ] I have made any necessary updates to the documentation
- [ ] I have checked there are no unnecessary IDE warnings in this PR
- [ ] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [ ] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [ ] If I have made any changes to content strings or resource files, I have followed [the documentation](https://github.com/UKGovernmentBEIS/beis-simple-energy-advice-beta/blob/main/docs/LocalisationDocumentation.md)
 