### PR TITLE
PC-1714 PC-1715: Fix incorrect IsPageHeading option

### DIFF
--- a/SeaPublicWebsite/Views/EnergyEfficiency/YourRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/YourRecommendations.cshtml
@@ -82,7 +82,7 @@
                                     </p>
                                 </text>,
                         Classes = "govuk-fieldset__legend--m",
-                        IsPageHeading = true,
+                        IsPageHeading = false,
                     },
                 },
                 conditionalOption: new Conditional


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1714)
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1715)

# Description

this option being true, in combination with no `Text` property being set was causes an empty `<h1>` to be placed onto the page

double checked, the rest of the legends in the project seem to be set correctly

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
 
# Screenshots

![image](https://github.com/user-attachments/assets/24b55929-c66d-426e-abdc-39999ec58543)
