### PR TITLE
PC-1753: Make page language identifier adapt to current culture

### DIFF
--- a/SeaPublicWebsite/Views/Shared/_Layout.cshtml
+++ b/SeaPublicWebsite/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
 <!-- Build number: @(BuildNumberHelper.GetBuildNumber()) -->
 <!-- Server name: @(Environment.MachineName) -->
 
-<html lang="en" class="govuk-template app-html-class">
+<html lang="@CultureInfo.CurrentCulture.TwoLetterISOLanguageName" class="govuk-template app-html-class">
 <head>
     @if (CookieService.HasAcceptedGoogleAnalytics(Context.Request))
     {


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1753)

# Description

Page language identifier shows current culture's ISO code, instead of just "en"

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4BNrG0=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to content strings or resource files, I have followed [the documentation]
