### PR TITLE
PC-1686: Fix FluentAssertions ignore version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     ignore:
       # ensure FluentAssertions doesn't update to 8.x as its new license prohibit commercial use
       - dependency-name: "FluentAssertions"
-        versions: ["8.x"]
+        versions: ["8.*"]
 
   - package-ecosystem: "npm"
     directory: "SeaPublicWebsite"


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1686)

# Description

specifically in nuget * must be used instead of x, see [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versions-ignore)

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable