### PR TITLE
PC-1760: --no-sandbox Documentation & Investigation Results

### DIFF
--- a/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
+++ b/SeaPublicWebsite/Services/EnergyEfficiency/PdfGeneration/PdfGenerationService.cs
@@ -17,6 +17,10 @@ public class PdfGenerationService(AuthService authService, PasswordService passw
             Headless = true,
             Args =
             [
+                /* Investigated this flag's removal in PC-1760
+                // Due to limitations with running chromium sandboxes in Fargate, we are unable to remove this flag
+                // See GitHub issue: https://github.com/aws/containers-roadmap/issues/2102
+                */ 
                 "--no-sandbox"
             ]
         };


### PR DESCRIPTION
Added documentation to the codebase referencing the findings from this ticket's investigation.


As part of this investigation I've also verified that the PDF generator uses localhost:8080+path, so it should only be able to generate PDFs of items within the app itself.