### PR TITLE
PC-1832: Change broken link URL to OFGEM schemes page

### DIFF
--- a/SeaPublicWebsite/Resources/SharedResources.cy.resx
+++ b/SeaPublicWebsite/Resources/SharedResources.cy.resx
@@ -2414,7 +2414,7 @@
         <value>Gallwch &lt;a href="{0}"&gt;ddychwelyd i’ch argymhellion a'ch cynllun gweithredu&lt;/a&gt; os oes angen.</value>
     </data>
     <data name="OfgemGuideToSchemesAndGrantsString" xml:space="preserve">
-        <value>Os ydych chi'n poeni am fforddio’ch biliau ynni, mae gan Ofgem &lt;a class="govuk-link" href="{0}" target="_blank"&gt;ganllaw defnyddiol&lt;/a&gt; i'r cynlluniau, y grantiau a'r budd-daliadau a allai fod ar gael ichi.</value>
+        <value>Os ydych chi'n poeni am fforddio’ch biliau ynni, mae gan Ofgem &lt;a class="govuk-link" href="{0}" target="_blank" rel="noreferrer noopener"&gt;ganllaw defnyddiol (yn agor mewn tab newydd)&lt;/a&gt; i'r cynlluniau, y grantiau a'r budd-daliadau a allai fod ar gael ichi.</value>
     </data>
     <data name="NewWindowsTypicallyLastString" xml:space="preserve">
         <value>Ar y cyfan, disgwylir i ffenestri newydd bara &lt;strong&gt;tua {0} o flynyddoedd&lt;/strong&gt;</value>

--- a/SeaPublicWebsite/Resources/SharedResources.resx
+++ b/SeaPublicWebsite/Resources/SharedResources.resx
@@ -1467,7 +1467,7 @@
         <value>Boiler Upgrade Scheme</value>
     </data>
     <data name="OfgemGuideToSchemesAndGrantsString" xml:space="preserve">
-        <value>If you are worried about affording your energy bills, Ofgem has a &lt;a class="govuk-link" href="{0}" target="_blank"&gt;helpful guide&lt;/a&gt; to the schemes, grants and benefits that may be available to you.</value>
+        <value>If you are worried about affording your energy bills, Ofgem has a &lt;a class="govuk-link" href="{0}" target="_blank" rel="noreferrer noopener"&gt;helpful guide (opens in a new tab)&lt;/a&gt; to the schemes, grants and benefits that may be available to you.</value>
     </data>
     <data name="2. Consult with a qualified installer" xml:space="preserve">
         <value>2. Consult with a qualified installer</value>

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/Partials/_AvailableSchemesOrGrants.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/Partials/_AvailableSchemesOrGrants.cshtml
@@ -24,7 +24,7 @@
 </p>
 
 <p class="govuk-body">
-    @SharedLocalizer["OfgemGuideToSchemesAndGrantsString", "https://www.ofgem.gov.uk/find-schemes-grants-and-benefits-help-home-energy"]
+    @SharedLocalizer["OfgemGuideToSchemesAndGrantsString", "https://www.ofgem.gov.uk/environmental-and-social-schemes"]
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1832)

# Description

- Updated broken OFGEM link destination for “helpful guides” to OFGEM environmental & social schemes [page](https://www.ofgem.gov.uk/environmental-and-social-schemes)
- Corrected link styling to GDS accessibility standard

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK4BNrG0=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to content strings or resource files, I have followed [the documentation](https://github.com/UKGovernmentBEIS/beis-simple-energy-advice-beta/blob/main/docs/LocalisationDocumentation.md)
 
# Screenshots

![image](https://github.com/user-attachments/assets/b45d753d-82aa-4e24-a046-010ed403b479)


