### PR TITLE
PC-1860: Update ignored dependency specification

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,10 @@ updates:
     ignore:
       # ensure FluentAssertions doesn't update to 8.x as its new license prohibits commercial use
       - dependency-name: "FluentAssertions"
-        versions: ["8.*.*"]
+        versions: ["8.x.x"]
       # Dependencies that cannot update to 9.x until we update to .NET 9
       - dependency-name: "Microsoft.EntityFrameworkCore.Design"
-        versions: ["9.*.*"]
+        versions: ["9.x.x"]
 
   - package-ecosystem: "npm"
     directory: "SeaPublicWebsite"


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1860)

# Description

use x over * in ignored dependency versions

it seems to be suggested that this is how GitHub intends you to do these ignored versions, though neither * or x have worked so far.

porting this from WH:LG so the spec is at least consistent between projects
