### PR TITLE
PC-1868: Update broken energy label link

### DIFF
--- a/SeaPublicWebsite/Resources/SharedResources.cy.resx
+++ b/SeaPublicWebsite/Resources/SharedResources.cy.resx
@@ -1297,7 +1297,7 @@
         <value>Ffyrdd eraill o arbed ynni</value>
     </data>
     <data name="WhenBuyingNewAppliancesUpgradeEnergyLabelsString" xml:space="preserve">
-        <value>Pan fyddwch chi’n prynu offer newydd, beth am uwchraddio i un sy'n defnyddio ynni'n effeithlon - Rhagor o wybodaeth am labeli ynni</value>
+        <value>Pan fyddwch chi’n prynu offer newydd, beth am uwchraddio i un sy'n defnyddio ynni'n effeithlon - &lt;a class="govuk-link" href="{0}" target="_blank" rel="noreferrer noopener"&gt; Rhagor o wybodaeth am labeli ynni (yn agor mewn tab newydd)&lt;/a&gt; ar wefan yr Ymddiriedolaeth Arbed Ynni.</value>
     </data>
     <data name="InstallHeatPumpCheckIfHomeSuitableString" xml:space="preserve">
         <value>Gosod pwmp gwres - Edrychwch a ydy eich cartref yn addas</value>

--- a/SeaPublicWebsite/Resources/SharedResources.cy.resx
+++ b/SeaPublicWebsite/Resources/SharedResources.cy.resx
@@ -2365,7 +2365,7 @@
         <value>Efallai y byddwn ni hefyd yn casglu ac yn prosesu gwybodaeth ddienw fel yr amlinellir yn ein &lt;a class="govuk-link" href="{0}" target="_blank"&gt;polisi cwcis&lt;/a&gt;.</value>
     </data>
     <data name="VisitTheHelpForHouseholdsWebsiteString" xml:space="preserve">
-        <value>Ewch i wefan &lt;a class="govuk-link" target="_blank" href="{0}"&gt;Help for Households&lt;/a&gt; i gael mwy byth o ffyrdd o arbed ynni a lleihau’ch biliau.</value>
+        <value>Ewch i wefan &lt;a class="govuk-link" target="_blank" href="{0}"&gt;Cymorth i Aelwydydd&lt;/a&gt; i gael mwy byth o ffyrdd o arbed ynni a lleihau’ch biliau.</value>
     </data>
     <data name="Saves your language preference" xml:space="preserve">
         <value>Yn cadw’ch dewis iaith</value>

--- a/SeaPublicWebsite/Resources/SharedResources.resx
+++ b/SeaPublicWebsite/Resources/SharedResources.resx
@@ -1019,7 +1019,7 @@
         <value>If you’d like to do more to improve the energy efficiency of your home, consider the following:</value>
     </data>
     <data name="WhenBuyingNewAppliancesUpgradeEnergyLabelsString" xml:space="preserve">
-        <value>When buying new appliances, upgrade to an energy efficient one - &lt;a class="govuk-link" target="_blank" href="{0}"&gt;Learn about energy labels&lt;/a&gt;</value>
+        <value>When buying new appliances, upgrade to an energy efficient one - &lt;a class="govuk-link" href="{0}" target="_blank" rel="noreferrer noopener"&gt; Learn about energy labels (opens in a new tab)&lt;/a&gt; on the Energy Saving Trust website.</value>
     </data>
     <data name="Install a heat pump – " xml:space="preserve">
         <value>Install a heat pump – </value>

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithDiscardedRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithDiscardedRecommendations.cshtml
@@ -44,7 +44,7 @@
             <li>
                 @SharedLocalizer["VisitTheHelpForHouseholdsWebsiteString", "https://helpforhouseholds.campaign.gov.uk/help-with-your-bills/energy-saving-advice/"]
             </li>
-            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energylabel.org.uk/"]</li>
+            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energysavingtrust.org.uk/advice/home-appliances/"]</li>
             @if (Model.PropertyData?.HasOutdoorSpace != HasOutdoorSpace.No)
             {
                 <li>@SharedLocalizer["InstallHeatPumpCheckIfHomeSuitableString", "https://www.heat-pump-check.service.gov.uk/"]</li>

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithMaybeRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithMaybeRecommendations.cshtml
@@ -44,7 +44,7 @@
             <li>
                 @SharedLocalizer["VisitTheHelpForHouseholdsWebsiteString", "https://helpforhouseholds.campaign.gov.uk/help-with-your-bills/energy-saving-advice/"]
             </li>
-            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energylabel.org.uk/"]</li>
+            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energysavingtrust.org.uk/advice/home-appliances/"]</li>
             @if (Model.PropertyData?.HasOutdoorSpace != HasOutdoorSpace.No)
             {
                 <li>@SharedLocalizer["InstallHeatPumpCheckIfHomeSuitableString", "https://www.heat-pump-check.service.gov.uk/"]</li>

--- a/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithSavedRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/ActionPlan/ActionPlanWithSavedRecommendations.cshtml
@@ -193,7 +193,7 @@
     <li>
         @SharedLocalizer["VisitTheHelpForHouseholdsWebsiteString", "https://helpforhouseholds.campaign.gov.uk/help-with-your-bills/energy-saving-advice/"]
     </li>
-    <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energylabel.org.uk/"]</li>
+    <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energysavingtrust.org.uk/advice/home-appliances/"]</li>
     @if (Model.PropertyData?.HasOutdoorSpace != HasOutdoorSpace.No)
     {
         <li>@SharedLocalizer["InstallHeatPumpCheckIfHomeSuitableString", "https://www.heat-pump-check.service.gov.uk/"]</li>

--- a/SeaPublicWebsite/Views/EnergyEfficiency/NoRecommendations.cshtml
+++ b/SeaPublicWebsite/Views/EnergyEfficiency/NoRecommendations.cshtml
@@ -38,7 +38,7 @@
         </p>
 
         <ul class="govuk-list govuk-list--bullet">
-            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energylabel.org.uk/"]</li>
+            <li>@SharedLocalizer["WhenBuyingNewAppliancesUpgradeEnergyLabelsString", "https://energysavingtrust.org.uk/advice/home-appliances/"]</li>
             @if (Model?.HasOutdoorSpace != HasOutdoorSpace.No)
             {
                 <li>@SharedLocalizer["InstallHeatPumpCheckIfHomeSuitableString", "https://www.heat-pump-check.service.gov.uk/"]</li>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1868)

# Description

- Updated "Help for household" link text translation (added to scope of this work as per client instruction [here](https://beisdigital.atlassian.net/browse/PC-1868?focusedCommentId=96382))
- Updated "learn about energy labels" link
     - Text updated to make it clear user is going to Energy Saving Trust
     - Translation in Cymraeg added

# Checklist

- [ ] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to content strings or resource files, I have followed [the documentation](https://github.com/UKGovernmentBEIS/beis-simple-energy-advice-beta/blob/main/docs/LocalisationDocumentation.md)
 
# Screenshots
## English link text
![image](https://github.com/user-attachments/assets/0301b5e5-0a07-4776-8b68-bc33e8447f7c)

## Cymraeg link text
![image](https://github.com/user-attachments/assets/4ba9b665-096b-49d9-92a0-9ae3e4321254)


