### PR TITLE
PC-NONE: Slight optimisation to Dockerfile during local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ ARG CONFIGURATION=Release
 
 WORKDIR /SeaPublicWebsite
 
-# Copy everything
-COPY . ./
-
 # Install NodeJS and NPM
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&\
 apt-get install -y nodejs
+
+# Copy everything
+COPY . ./
 
 # Build node assets
 WORKDIR /SeaPublicWebsite/SeaPublicWebsite


### PR DESCRIPTION
install node before copying files in Dockerfile

ensures that this step can be correctly cached & doesn't re-run on any file changes in the project

helps out local dev build times
