### PR TITLE
PC-2016: Pin google chrome version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 # Install Chrome
 RUN apt-get update && apt-get -f install && apt-get -y install wget gnupg2 apt-utils
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list
+
+# latest google-chrome-stable can be found at https://www.ubuntuupdates.org/pm/google-chrome-stable
+ARG CHROME_VERSION=139.0.7258.138-1
+RUN wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+  && apt install -y /tmp/chrome.deb --no-install-recommends \
+  && rm /tmp/chrome.deb
+
 RUN apt-get update \
-    && apt-get install -y google-chrome-stable --no-install-recommends --allow-downgrades fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
+    && apt-get install -y --no-install-recommends fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf
+
 ENV PUPPETEER_EXECUTABLE_PATH="/usr/bin/google-chrome-stable"
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-2016)

# Description

to 139.0.7258.138-1

restructures install code a little to allow for this. we can't use version= syntax as google remove old versions from the PPA repository very quickly so the install will fail as the old version cannot be found. downloads the .deb install file instead manually and installs that which seems to be more stable

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
