### PR TITLE
DESNZ-None: Bump trivy to safe version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
           docker build -t app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'app:${{ github.sha }}'
           exit-code: '1'


### PR DESCRIPTION
See  https://github.com/aquasecurity/trivy-action/issues/541

Bump to safe version